### PR TITLE
Add trusted types compatibility

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -18,7 +18,7 @@
   // Use 'forwardPorts' to make a list of ports inside the container available locally.
   // "forwardPorts": [],
   // Use 'postCreateCommand' to run commands after the container is created.
-  "postCreateCommand": "yarn install && yarn build",
+  "postCreateCommand": "yarn install && yarn build && yarn run playwright install",
   // Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
   "remoteUser": "node"
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,3 +37,6 @@ jobs:
 
     - name: Firefox Test
       run: yarn test:browser --project=firefox
+
+    - name: Chrome With Trusted Types Test
+      run: yarn test:browser --project=chrome-with-trusted-types

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -10,6 +10,10 @@ const config: PlaywrightTestConfig = {
       name: "firefox",
       use: { ...devices["Desktop Firefox"] },
     },
+    {
+      name: "chrome-with-trusted-types",
+      use: { ...devices["Desktop Chrome"] },
+    },
   ],
   retries: 2,
   testDir: "./src/tests/functional",

--- a/src/core/drive/navigator.ts
+++ b/src/core/drive/navigator.ts
@@ -96,7 +96,7 @@ export class Navigator {
         const visitOptions = {
           action,
           shouldCacheSnapshot,
-          response: { statusCode, redirected, response },
+          response: { statusCode, redirected, response, responseHTML },
         }
 
         const location = fetchResponse.location
@@ -112,7 +112,7 @@ export class Navigator {
     const responseHTML = await fetchResponse.responseHTML
 
     if (responseHTML) {
-      const snapshot = await PageSnapshot.fromResponse(fetchResponse.response)
+      const snapshot = PageSnapshot.fromResponse(fetchResponse.response, responseHTML)
 
       if (fetchResponse.serverError) {
         await this.view.renderError(snapshot, this.currentVisit)

--- a/src/core/drive/navigator.ts
+++ b/src/core/drive/navigator.ts
@@ -91,12 +91,12 @@ export class Navigator {
           this.view.clearSnapshotCache()
         }
 
-        const { statusCode, redirected } = fetchResponse
+        const { statusCode, redirected, response } = fetchResponse
         const action = this.getActionForFormSubmission(formSubmission)
         const visitOptions = {
           action,
           shouldCacheSnapshot,
-          response: { statusCode, responseHTML, redirected },
+          response: { statusCode, redirected, response },
         }
 
         const location = fetchResponse.location
@@ -112,7 +112,8 @@ export class Navigator {
     const responseHTML = await fetchResponse.responseHTML
 
     if (responseHTML) {
-      const snapshot = PageSnapshot.fromHTMLString(responseHTML)
+      const snapshot = await PageSnapshot.fromResponse(fetchResponse.response)
+
       if (fetchResponse.serverError) {
         await this.view.renderError(snapshot, this.currentVisit)
       } else {

--- a/src/core/drive/page_snapshot.ts
+++ b/src/core/drive/page_snapshot.ts
@@ -1,10 +1,24 @@
+import { CSPTrustedTypesPolicy, emptyHTML } from "../../trusted_types"
 import { parseHTMLDocument } from "../../util"
 import { Snapshot } from "../snapshot"
 import { expandURL } from "../url"
 import { HeadSnapshot } from "./head_snapshot"
 
 export class PageSnapshot extends Snapshot<HTMLBodyElement> {
-  static fromHTMLString(html = "") {
+  static async fromResponse(response?: Response): Promise<PageSnapshot> {
+    if (!response) {
+      return this.fromHTMLString()
+    }
+    const responseText = await response.text()
+    if (CSPTrustedTypesPolicy == null) {
+      return this.fromHTMLString(responseText)
+    } else {
+      const trustedHTML = CSPTrustedTypesPolicy.createHTML(responseText, response)
+      return this.fromHTMLString(trustedHTML as string)
+    }
+  }
+
+  static fromHTMLString(html = emptyHTML) {
     return this.fromDocument(parseHTMLDocument(html))
   }
 

--- a/src/core/drive/page_snapshot.ts
+++ b/src/core/drive/page_snapshot.ts
@@ -5,17 +5,13 @@ import { expandURL } from "../url"
 import { HeadSnapshot } from "./head_snapshot"
 
 export class PageSnapshot extends Snapshot<HTMLBodyElement> {
-  static async fromResponse(response?: Response): Promise<PageSnapshot> {
-    if (!response) {
-      return this.fromHTMLString()
+  static fromResponse(response?: Response, html = emptyHTML): PageSnapshot {
+    if (!response || CSPTrustedTypesPolicy == null) {
+      return this.fromHTMLString(html)
     }
-    const responseText = await response.text()
-    if (CSPTrustedTypesPolicy == null) {
-      return this.fromHTMLString(responseText)
-    } else {
-      const trustedHTML = CSPTrustedTypesPolicy.createHTML(responseText, response)
-      return this.fromHTMLString(trustedHTML as string)
-    }
+
+    const trustedHTML = CSPTrustedTypesPolicy.createHTML(html, response)
+    return this.fromHTMLString(trustedHTML as string)
   }
 
   static fromHTMLString(html = emptyHTML) {

--- a/src/core/drive/preloader.ts
+++ b/src/core/drive/preloader.ts
@@ -43,8 +43,7 @@ export class Preloader {
 
     try {
       const response = await fetch(location.toString(), { headers: { "VND.PREFETCH": "true", Accept: "text/html" } })
-      const responseText = await response.text()
-      const snapshot = PageSnapshot.fromHTMLString(responseText)
+      const snapshot = await PageSnapshot.fromResponse(response)
 
       this.snapshotCache.put(location, snapshot)
     } catch (_) {

--- a/src/core/drive/preloader.ts
+++ b/src/core/drive/preloader.ts
@@ -43,7 +43,8 @@ export class Preloader {
 
     try {
       const response = await fetch(location.toString(), { headers: { "VND.PREFETCH": "true", Accept: "text/html" } })
-      const snapshot = await PageSnapshot.fromResponse(response)
+      const responseText = await response.text()
+      const snapshot = PageSnapshot.fromResponse(response, responseText)
 
       this.snapshotCache.put(location, snapshot)
     } catch (_) {

--- a/src/core/drive/visit.ts
+++ b/src/core/drive/visit.ts
@@ -354,14 +354,13 @@ export class Visit implements FetchRequestDelegate {
       this.recordResponse({
         statusCode: SystemStatusCode.contentTypeMismatch,
         redirected,
-        response,
       })
     } else {
       this.redirectedToLocation = fetchResponse.redirected ? fetchResponse.location : undefined
       if (this.redirectedToLocation && fetchResponse.location.hash === "") {
         this.redirectedToLocation.hash = request.url.hash
       }
-      this.recordResponse({ statusCode: statusCode, redirected, response })
+      this.recordResponse({ statusCode: statusCode, response, redirected })
     }
   }
 
@@ -372,10 +371,9 @@ export class Visit implements FetchRequestDelegate {
       this.recordResponse({
         statusCode: SystemStatusCode.contentTypeMismatch,
         redirected,
-        response,
       })
     } else {
-      this.recordResponse({ statusCode: statusCode, redirected, response })
+      this.recordResponse({ statusCode: statusCode, response, redirected })
     }
   }
 

--- a/src/core/drive/visit.ts
+++ b/src/core/drive/visit.ts
@@ -68,6 +68,7 @@ export type VisitResponse = {
   statusCode: number
   redirected: boolean
   response?: Response
+  responseHTML?: string
 }
 
 export enum SystemStatusCode {
@@ -253,17 +254,17 @@ export class Visit implements FetchRequestDelegate {
 
   loadResponse() {
     if (this.response) {
-      const { statusCode, response } = this.response
+      const { statusCode, response, responseHTML } = this.response
       this.render(async () => {
         if (this.shouldCacheSnapshot) this.cacheSnapshot()
         if (this.view.renderPromise) await this.view.renderPromise
-        if (isSuccessful(statusCode) && response != null) {
-          await this.view.renderPage(await PageSnapshot.fromResponse(response), false, this.willRender, this)
+        if (isSuccessful(statusCode) && responseHTML != null) {
+          await this.view.renderPage(PageSnapshot.fromResponse(response, responseHTML), false, this.willRender, this)
           this.performScroll()
           this.adapter.visitRendered(this)
           this.complete()
         } else {
-          await this.view.renderError(await PageSnapshot.fromResponse(response), this)
+          await this.view.renderError(PageSnapshot.fromResponse(response, responseHTML), this)
           this.adapter.visitRendered(this)
           this.fail()
         }
@@ -360,7 +361,7 @@ export class Visit implements FetchRequestDelegate {
       if (this.redirectedToLocation && fetchResponse.location.hash === "") {
         this.redirectedToLocation.hash = request.url.hash
       }
-      this.recordResponse({ statusCode: statusCode, redirected, response })
+      this.recordResponse({ statusCode: statusCode, redirected, response, responseHTML })
     }
   }
 
@@ -373,7 +374,7 @@ export class Visit implements FetchRequestDelegate {
         redirected,
       })
     } else {
-      this.recordResponse({ statusCode: statusCode, redirected, response })
+      this.recordResponse({ statusCode: statusCode, redirected, response, responseHTML })
     }
   }
 

--- a/src/core/drive/visit.ts
+++ b/src/core/drive/visit.ts
@@ -67,7 +67,7 @@ const defaultOptions: VisitOptions = {
 export type VisitResponse = {
   statusCode: number
   redirected: boolean
-  responseHTML?: string
+  response?: Response
 }
 
 export enum SystemStatusCode {
@@ -253,17 +253,17 @@ export class Visit implements FetchRequestDelegate {
 
   loadResponse() {
     if (this.response) {
-      const { statusCode, responseHTML } = this.response
+      const { statusCode, response } = this.response
       this.render(async () => {
         if (this.shouldCacheSnapshot) this.cacheSnapshot()
         if (this.view.renderPromise) await this.view.renderPromise
-        if (isSuccessful(statusCode) && responseHTML != null) {
-          await this.view.renderPage(PageSnapshot.fromHTMLString(responseHTML), false, this.willRender, this)
+        if (isSuccessful(statusCode) && response != null) {
+          await this.view.renderPage(await PageSnapshot.fromResponse(response), false, this.willRender, this)
           this.performScroll()
           this.adapter.visitRendered(this)
           this.complete()
         } else {
-          await this.view.renderError(PageSnapshot.fromHTMLString(responseHTML), this)
+          await this.view.renderError(await PageSnapshot.fromResponse(response), this)
           this.adapter.visitRendered(this)
           this.fail()
         }
@@ -347,33 +347,35 @@ export class Visit implements FetchRequestDelegate {
 
   requestPreventedHandlingResponse(_request: FetchRequest, _response: FetchResponse) {}
 
-  async requestSucceededWithResponse(request: FetchRequest, response: FetchResponse) {
-    const responseHTML = await response.responseHTML
-    const { redirected, statusCode } = response
+  async requestSucceededWithResponse(request: FetchRequest, fetchResponse: FetchResponse) {
+    const responseHTML = await fetchResponse.responseHTML
+    const { redirected, statusCode, response } = fetchResponse
     if (responseHTML == undefined) {
       this.recordResponse({
         statusCode: SystemStatusCode.contentTypeMismatch,
         redirected,
+        response,
       })
     } else {
-      this.redirectedToLocation = response.redirected ? response.location : undefined
-      if (this.redirectedToLocation && response.location.hash === "") {
+      this.redirectedToLocation = fetchResponse.redirected ? fetchResponse.location : undefined
+      if (this.redirectedToLocation && fetchResponse.location.hash === "") {
         this.redirectedToLocation.hash = request.url.hash
       }
-      this.recordResponse({ statusCode: statusCode, responseHTML, redirected })
+      this.recordResponse({ statusCode: statusCode, redirected, response })
     }
   }
 
-  async requestFailedWithResponse(request: FetchRequest, response: FetchResponse) {
-    const responseHTML = await response.responseHTML
-    const { redirected, statusCode } = response
+  async requestFailedWithResponse(request: FetchRequest, fetchResponse: FetchResponse) {
+    const responseHTML = await fetchResponse.responseHTML
+    const { redirected, statusCode, response } = fetchResponse
     if (responseHTML == undefined) {
       this.recordResponse({
         statusCode: SystemStatusCode.contentTypeMismatch,
         redirected,
+        response,
       })
     } else {
-      this.recordResponse({ statusCode: statusCode, responseHTML, redirected })
+      this.recordResponse({ statusCode: statusCode, redirected, response })
     }
   }
 

--- a/src/core/drive/visit.ts
+++ b/src/core/drive/visit.ts
@@ -354,13 +354,14 @@ export class Visit implements FetchRequestDelegate {
       this.recordResponse({
         statusCode: SystemStatusCode.contentTypeMismatch,
         redirected,
+        response,
       })
     } else {
       this.redirectedToLocation = fetchResponse.redirected ? fetchResponse.location : undefined
       if (this.redirectedToLocation && fetchResponse.location.hash === "") {
         this.redirectedToLocation.hash = request.url.hash
       }
-      this.recordResponse({ statusCode: statusCode, response, redirected })
+      this.recordResponse({ statusCode: statusCode, redirected, response })
     }
   }
 
@@ -371,9 +372,10 @@ export class Visit implements FetchRequestDelegate {
       this.recordResponse({
         statusCode: SystemStatusCode.contentTypeMismatch,
         redirected,
+        response,
       })
     } else {
-      this.recordResponse({ statusCode: statusCode, response, redirected })
+      this.recordResponse({ statusCode: statusCode, redirected, response })
     }
   }
 

--- a/src/core/drive/visit.ts
+++ b/src/core/drive/visit.ts
@@ -354,7 +354,6 @@ export class Visit implements FetchRequestDelegate {
       this.recordResponse({
         statusCode: SystemStatusCode.contentTypeMismatch,
         redirected,
-        response,
       })
     } else {
       this.redirectedToLocation = fetchResponse.redirected ? fetchResponse.location : undefined
@@ -372,7 +371,6 @@ export class Visit implements FetchRequestDelegate {
       this.recordResponse({
         statusCode: SystemStatusCode.contentTypeMismatch,
         redirected,
-        response,
       })
     } else {
       this.recordResponse({ statusCode: statusCode, redirected, response })

--- a/src/core/frames/frame_controller.ts
+++ b/src/core/frames/frame_controller.ts
@@ -469,9 +469,10 @@ export class FrameController
 
   private async visitResponse(response: Response): Promise<void> {
     const wrapped = new FetchResponse(response)
+    const responseHTML = await wrapped.responseHTML
     const { location, redirected, statusCode } = wrapped
 
-    return session.visit(location, { response: { redirected, statusCode, response } })
+    return session.visit(location, { response: { redirected, statusCode, response, responseHTML } })
   }
 
   private findFrameElement(element: Element, submitter?: HTMLElement) {

--- a/src/core/frames/frame_controller.ts
+++ b/src/core/frames/frame_controller.ts
@@ -421,7 +421,13 @@ export class FrameController
       frame.delegate.fetchResponseLoaded = (fetchResponse: FetchResponse) => {
         if (frame.src) {
           const { statusCode, redirected, response } = fetchResponse
-          const visitResponse = { statusCode, redirected, response }
+          const responseHTML = frame.ownerDocument.documentElement.outerHTML
+          const frameResponse = new Response(responseHTML, {
+            status: statusCode,
+            statusText: response.statusText,
+            headers: response.headers,
+          })
+          const visitResponse = { statusCode, redirected, frameResponse }
           const options: Partial<VisitOptions> = {
             response: visitResponse,
             visitCachedSnapshot,

--- a/src/core/frames/frame_controller.ts
+++ b/src/core/frames/frame_controller.ts
@@ -421,7 +421,8 @@ export class FrameController
       frame.delegate.fetchResponseLoaded = (fetchResponse: FetchResponse) => {
         if (frame.src) {
           const { statusCode, redirected, response } = fetchResponse
-          const visitResponse = { statusCode, redirected, response }
+          const responseHTML = frame.ownerDocument.documentElement.outerHTML
+          const visitResponse = { statusCode, redirected, response, responseHTML }
           const options: Partial<VisitOptions> = {
             response: visitResponse,
             visitCachedSnapshot,

--- a/src/core/frames/frame_controller.ts
+++ b/src/core/frames/frame_controller.ts
@@ -421,13 +421,7 @@ export class FrameController
       frame.delegate.fetchResponseLoaded = (fetchResponse: FetchResponse) => {
         if (frame.src) {
           const { statusCode, redirected, response } = fetchResponse
-          const responseHTML = frame.ownerDocument.documentElement.outerHTML
-          const frameResponse = new Response(responseHTML, {
-            status: statusCode,
-            statusText: response.statusText,
-            headers: response.headers,
-          })
-          const visitResponse = { statusCode, redirected, frameResponse }
+          const visitResponse = { statusCode, redirected, response }
           const options: Partial<VisitOptions> = {
             response: visitResponse,
             visitCachedSnapshot,

--- a/src/core/frames/frame_view.ts
+++ b/src/core/frames/frame_view.ts
@@ -6,7 +6,7 @@ export type FrameViewRenderOptions = ViewRenderOptions<FrameElement>
 
 export class FrameView extends View<FrameElement> {
   invalidate() {
-    this.element.innerHTML = ""
+    this.element.textContent = ""
   }
 
   get snapshot() {

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -32,6 +32,7 @@ export { TurboSubmitStartEvent, TurboSubmitEndEvent } from "./drive/form_submiss
 export { TurboFrameMissingEvent } from "./frames/frame_controller"
 
 export { StreamActions, TurboStreamAction, TurboStreamActions } from "./streams/stream_actions"
+export { setCSPTrustedTypesPolicy } from "../trusted_types"
 
 /**
  * Starts the main session.

--- a/src/elements/frame_element.ts
+++ b/src/elements/frame_element.ts
@@ -2,6 +2,7 @@ import { FetchResponse } from "../http/fetch_response"
 import { Snapshot } from "../core/snapshot"
 import { LinkInterceptorDelegate } from "../core/frames/link_interceptor"
 import { FormSubmitObserverDelegate } from "../observers/form_submit_observer"
+import { CSPTrustedTypesPolicy } from "../trusted_types"
 
 export enum FrameLoadingStyle {
   eager = "eager",
@@ -93,7 +94,12 @@ export class FrameElement extends HTMLElement {
    */
   set src(value: string | null) {
     if (value) {
-      this.setAttribute("src", value)
+      if (CSPTrustedTypesPolicy) {
+        const trustedValue = CSPTrustedTypesPolicy.createScriptURL(value)
+        this.setAttribute("src", trustedValue as string)
+      } else {
+        this.setAttribute("src", value)
+      }
     } else {
       this.removeAttribute("src")
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,3 +10,4 @@ Turbo.start()
 export * from "./core"
 export * from "./elements"
 export * from "./http"
+export * from "./trusted_types"

--- a/src/tests/functional/async_script_tests.ts
+++ b/src/tests/functional/async_script_tests.ts
@@ -1,3 +1,4 @@
+import "../helpers/trusted_type_setup"
 import { test } from "@playwright/test"
 import { assert } from "chai"
 import { readEventLogs, visitAction } from "../helpers/page"

--- a/src/tests/functional/autofocus_tests.ts
+++ b/src/tests/functional/autofocus_tests.ts
@@ -1,3 +1,4 @@
+import "../helpers/trusted_type_setup"
 import { test } from "@playwright/test"
 import { assert } from "chai"
 import { hasSelector, nextBeat } from "../helpers/page"

--- a/src/tests/functional/cache_observer_tests.ts
+++ b/src/tests/functional/cache_observer_tests.ts
@@ -1,3 +1,4 @@
+import "../helpers/trusted_type_setup"
 import { test } from "@playwright/test"
 import { assert } from "chai"
 import { hasSelector, nextBody } from "../helpers/page"

--- a/src/tests/functional/drive_disabled_tests.ts
+++ b/src/tests/functional/drive_disabled_tests.ts
@@ -1,3 +1,4 @@
+import "../helpers/trusted_type_setup"
 import { test } from "@playwright/test"
 import { assert } from "chai"
 import {

--- a/src/tests/functional/drive_tests.ts
+++ b/src/tests/functional/drive_tests.ts
@@ -1,3 +1,4 @@
+import "../helpers/trusted_type_setup"
 import { test } from "@playwright/test"
 import { assert } from "chai"
 import { nextBody, pathname, visitAction } from "../helpers/page"

--- a/src/tests/functional/form_mode_tests.ts
+++ b/src/tests/functional/form_mode_tests.ts
@@ -1,3 +1,4 @@
+import "../helpers/trusted_type_setup"
 import { Page, test } from "@playwright/test"
 import { getFromLocalStorage, setLocalStorageFromEvent } from "../helpers/page"
 import { assert } from "chai"

--- a/src/tests/functional/frame_navigation_tests.ts
+++ b/src/tests/functional/frame_navigation_tests.ts
@@ -1,3 +1,4 @@
+import "../helpers/trusted_type_setup"
 import { test } from "@playwright/test"
 import {
   getFromLocalStorage,

--- a/src/tests/functional/frame_tests.ts
+++ b/src/tests/functional/frame_tests.ts
@@ -1,3 +1,4 @@
+import "../helpers/trusted_type_setup"
 import { Page, test } from "@playwright/test"
 import { assert, Assertion } from "chai"
 import {

--- a/src/tests/functional/import_tests.ts
+++ b/src/tests/functional/import_tests.ts
@@ -1,3 +1,4 @@
+import "../helpers/trusted_type_setup"
 import { test } from "@playwright/test"
 import { assert } from "chai"
 

--- a/src/tests/functional/loading_tests.ts
+++ b/src/tests/functional/loading_tests.ts
@@ -1,3 +1,4 @@
+import "../helpers/trusted_type_setup"
 import { test } from "@playwright/test"
 import { assert } from "chai"
 import {

--- a/src/tests/functional/navigation_tests.ts
+++ b/src/tests/functional/navigation_tests.ts
@@ -1,3 +1,4 @@
+import "../helpers/trusted_type_setup"
 import { test } from "@playwright/test"
 import { assert } from "chai"
 import {

--- a/src/tests/functional/page_snapshot_tests.ts
+++ b/src/tests/functional/page_snapshot_tests.ts
@@ -1,0 +1,52 @@
+import { test } from "@playwright/test"
+import { assert } from "chai"
+
+test.beforeEach(async ({ page }) => {
+  await page.goto("/src/tests/fixtures/form.html")
+  await page.evaluate(() =>
+    window.Turbo.setCSPTrustedTypesPolicy({
+      createHTML: (s: string, response: Response) => {
+        console.log("---------- ", s)
+        response.headers.append("X-TRUSTED", "true")
+
+        return s.replace("Text", "Trusted")
+      },
+      createScript: (s) => s,
+      createScriptURL: (s) => s,
+    })
+  )
+})
+
+test.afterEach(async ({ page }) => {
+  await page.evaluate(() => window.Turbo.setCSPTrustedTypesPolicy(null))
+})
+
+const mockHTML = `
+<html>
+  <head></head>
+  <body><div>Text</div></body>
+</html>`
+
+test("test fromResponse applies CSP Policies", async ({ page }) => {
+  const [text, header] = await page.evaluate((html) => {
+    const response = new Response(html)
+    const snapshot = window.Turbo.PageSnapshot.fromResponse(response, html)
+    return [snapshot.element.innerText, response.headers.get("X-TRUSTED")]
+  }, mockHTML)
+
+  assert.include(text, "Trusted")
+  assert.equal(header, "true")
+})
+
+test("test fromResponse without CSP policy doesn't change the response", async ({ page }) => {
+  await page.evaluate(() => window.Turbo.setCSPTrustedTypesPolicy(null))
+
+  const [text, header] = await page.evaluate((html) => {
+    const response = new Response(html)
+    const snapshot = window.Turbo.PageSnapshot.fromResponse(response, html)
+    return [snapshot.element.innerText, response.headers.get("X-TRUSTED")]
+  }, mockHTML)
+
+  assert.include(text, "Text")
+  assert.equal(header, undefined)
+})

--- a/src/tests/functional/page_snapshot_tests.ts
+++ b/src/tests/functional/page_snapshot_tests.ts
@@ -2,8 +2,7 @@ import "../helpers/trusted_type_setup"
 import { test } from "@playwright/test"
 import { assert } from "chai"
 
-test.beforeEach(async ({ page }, workerInfo) => {
-  console.log(workerInfo.project.name)
+test.beforeEach(async ({ page }) => {
   await page.goto("/src/tests/fixtures/form.html")
   await page.evaluate(() =>
     window.Turbo.setCSPTrustedTypesPolicy({

--- a/src/tests/functional/page_snapshot_tests.ts
+++ b/src/tests/functional/page_snapshot_tests.ts
@@ -1,12 +1,13 @@
+import "../helpers/trusted_type_setup"
 import { test } from "@playwright/test"
 import { assert } from "chai"
 
-test.beforeEach(async ({ page }) => {
+test.beforeEach(async ({ page }, workerInfo) => {
+  console.log(workerInfo.project.name)
   await page.goto("/src/tests/fixtures/form.html")
   await page.evaluate(() =>
     window.Turbo.setCSPTrustedTypesPolicy({
       createHTML: (s: string, response: Response) => {
-        console.log("---------- ", s)
         response.headers.append("X-TRUSTED", "true")
 
         return s.replace("Text", "Trusted")

--- a/src/tests/functional/pausable_rendering_tests.ts
+++ b/src/tests/functional/pausable_rendering_tests.ts
@@ -1,3 +1,4 @@
+import "../helpers/trusted_type_setup"
 import { test } from "@playwright/test"
 import { assert } from "chai"
 import { nextBeat } from "../helpers/page"

--- a/src/tests/functional/pausable_requests_tests.ts
+++ b/src/tests/functional/pausable_requests_tests.ts
@@ -1,3 +1,4 @@
+import "../helpers/trusted_type_setup"
 import { test } from "@playwright/test"
 import { assert } from "chai"
 import { nextBeat } from "../helpers/page"

--- a/src/tests/functional/preloader_tests.ts
+++ b/src/tests/functional/preloader_tests.ts
@@ -1,3 +1,4 @@
+import "../helpers/trusted_type_setup"
 import { test } from "@playwright/test"
 import { assert } from "chai"
 import { nextBeat } from "../helpers/page"

--- a/src/tests/functional/rendering_tests.ts
+++ b/src/tests/functional/rendering_tests.ts
@@ -1,3 +1,4 @@
+import "../helpers/trusted_type_setup"
 import { JSHandle, Page, test } from "@playwright/test"
 import { assert } from "chai"
 import {

--- a/src/tests/functional/scroll_restoration_tests.ts
+++ b/src/tests/functional/scroll_restoration_tests.ts
@@ -1,3 +1,4 @@
+import "../helpers/trusted_type_setup"
 import { test } from "@playwright/test"
 import { assert } from "chai"
 import { nextBeat, scrollPosition, scrollToSelector } from "../helpers/page"

--- a/src/tests/functional/stream_tests.ts
+++ b/src/tests/functional/stream_tests.ts
@@ -1,3 +1,4 @@
+import "../helpers/trusted_type_setup"
 import { test } from "@playwright/test"
 import { assert } from "chai"
 import { nextBeat, nextEventNamed, readEventLogs } from "../helpers/page"

--- a/src/tests/functional/ujs_tests.ts
+++ b/src/tests/functional/ujs_tests.ts
@@ -1,3 +1,4 @@
+import "../helpers/trusted_type_setup"
 import { Page, test } from "@playwright/test"
 import { assert } from "chai"
 import { noNextEventOnTarget } from "../helpers/page"

--- a/src/tests/functional/visit_tests.ts
+++ b/src/tests/functional/visit_tests.ts
@@ -1,3 +1,4 @@
+import "../helpers/trusted_type_setup"
 import { Page, test } from "@playwright/test"
 import { assert } from "chai"
 import { get } from "http"

--- a/src/tests/functional/visitable_tests.ts
+++ b/src/tests/functional/visitable_tests.ts
@@ -1,3 +1,4 @@
+import "../helpers/trusted_type_setup"
 import { test } from "@playwright/test"
 import { assert } from "chai"
 import { nextBody, pathname, visitAction } from "../helpers/page"

--- a/src/tests/helpers/trusted_type_setup.ts
+++ b/src/tests/helpers/trusted_type_setup.ts
@@ -1,0 +1,19 @@
+import "../helpers/trusted_type_setup"
+import { test } from "@playwright/test"
+
+test.beforeEach(async ({ page }, workerInfo) => {
+  if (workerInfo.project.name === "chrome-with-trusted-types") {
+    await page.goto("/src/tests/fixtures/form.html")
+    await page.evaluate(() =>
+      window.Turbo.setCSPTrustedTypesPolicy({
+        createHTML: (s) => s,
+        createScript: (s) => s,
+        createScriptURL: (s) => s,
+      })
+    )
+  }
+})
+
+test.afterEach(async ({ page }) => {
+  await page.evaluate(() => window.Turbo.setCSPTrustedTypesPolicy(null))
+})

--- a/src/tests/runner.js
+++ b/src/tests/runner.js
@@ -1,8 +1,11 @@
 const { TestServer } = require("../../dist/tests/server")
+const { execSync } = require("child_process")
 const configuration = require("../../intern.json")
 const intern = require("intern").default
 const arg = require("arg");
-const { CHROMEVER } = process.env
+
+// In codespaces, we can automatically detect the Chrome Driver version, on local machines we know less about the setup so we cannot.
+const CHROMEVER = process.env["CHROMEVER"] || (process.env["CODESPACES"] ? execSync("chromedriver --version | cut -d' ' -f2").toString().trim() : undefined)
 
 const args = arg({
   "--grep": String,

--- a/src/trusted_types.ts
+++ b/src/trusted_types.ts
@@ -22,7 +22,7 @@ interface TrustedTypesPolicyInterface {
 
 let CSPTrustedTypesPolicy: CSPTrustedTypesPolicy | null = null
 
-export function setCSPTrustedTypesPolicy(policy: CSPTrustedTypesPolicy) {
+export function setCSPTrustedTypesPolicy(policy: CSPTrustedTypesPolicy | null) {
   CSPTrustedTypesPolicy = policy
 }
 

--- a/src/trusted_types.ts
+++ b/src/trusted_types.ts
@@ -1,0 +1,36 @@
+interface CSPTrustedHTMLToStringable {
+  toString: () => string
+}
+
+interface CSPTrustedScriptToStringable {
+  toString: () => string
+}
+
+interface CSPTrustedScriptUrlToStringable {
+  toString: () => string
+}
+
+interface CSPTrustedTypesPolicy {
+  createHTML: (s: string, r: Response) => CSPTrustedHTMLToStringable
+  createScript: (s: string) => CSPTrustedScriptToStringable
+  createScriptURL: (s: string) => CSPTrustedScriptUrlToStringable
+}
+
+interface TrustedTypesPolicyInterface {
+  emptyHTML: string
+}
+
+let CSPTrustedTypesPolicy: CSPTrustedTypesPolicy | null = null
+
+export function setCSPTrustedTypesPolicy(policy: CSPTrustedTypesPolicy) {
+  CSPTrustedTypesPolicy = policy
+}
+
+type GlobalThis = typeof globalThis
+interface TrustedTypesGlobalThis extends GlobalThis {
+  trustedTypes?: TrustedTypesPolicyInterface
+}
+
+export const emptyHTML = (globalThis as TrustedTypesGlobalThis).trustedTypes?.emptyHTML ?? ""
+
+export { CSPTrustedTypesPolicy }

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,4 +1,5 @@
 import { Action, isAction } from "./core/types"
+import { CSPTrustedTypesPolicy } from "./trusted_types"
 
 export type DispatchOptions<T extends CustomEvent> = {
   target: EventTarget
@@ -17,7 +18,7 @@ export function activateScriptElement(element: HTMLScriptElement) {
     }
     createdScriptElement.textContent = element.textContent
     createdScriptElement.async = false
-    copyElementAttributes(createdScriptElement, element)
+    copyScriptAttributes(createdScriptElement, element)
     return createdScriptElement
   }
 }
@@ -35,6 +36,17 @@ export function activateImageElement(element: HTMLImageElement) {
 function copyElementAttributes(destinationElement: Element, sourceElement: Element) {
   for (const { name, value } of sourceElement.attributes) {
     destinationElement.setAttribute(name, value)
+  }
+}
+
+function copyScriptAttributes(destinationElement: HTMLScriptElement, sourceElement: HTMLScriptElement) {
+  for (const { name, value } of sourceElement.attributes) {
+    if (name === "src" && CSPTrustedTypesPolicy !== null) {
+      const trustedElementSrc = CSPTrustedTypesPolicy.createScriptURL(value as string)
+      destinationElement.setAttribute(name, trustedElementSrc as string)
+    } else {
+      destinationElement.setAttribute(name, value)
+    }
   }
 }
 


### PR DESCRIPTION
This PR enables turbo clients to route a trusted types policy through to the library. This policy will be called at all dangerous injection sinks. The response object will be passed to the policy, along with the HTML as a string.