### PR TITLE
Fix trusted types for when a script is created from source

### DIFF
--- a/src/tests/unit/index.ts
+++ b/src/tests/unit/index.ts
@@ -1,3 +1,4 @@
 export * from "./export_tests"
 export * from "./deprecated_adapter_support_test"
 export * from "./stream_element_tests"
+export * from "./util_tests"

--- a/src/tests/unit/util_tests.ts
+++ b/src/tests/unit/util_tests.ts
@@ -1,0 +1,53 @@
+import * as Turbo from "../../index"
+import { DOMTestCase } from "../helpers/dom_test_case"
+import { activateScriptElement } from "../../util"
+
+export class UtilTests extends DOMTestCase {
+  async setup() {
+    Turbo.setCSPTrustedTypesPolicy({
+      createHTML: (_) => "bar",
+      createScript: (_) => "bar",
+      createScriptURL: (_) => "https://bar/",
+    })
+  }
+
+  async teardown() {
+    Turbo.setCSPTrustedTypesPolicy(null)
+  }
+
+  async "test TrustedTypes activates a script with source code"() {
+    const element = document.createElement("script")
+    element.textContent = "foo"
+
+    const activatedElement = activateScriptElement(element)
+    this.assert.equal(activatedElement.textContent, "bar")
+  }
+
+  async "test TyrustedTypes activates a script with source url"() {
+    const element = document.createElement("script")
+    element.src = "https://foo/"
+
+    const activatedElement = activateScriptElement(element)
+    this.assert.equal(activatedElement.src, "https://bar/")
+  }
+
+  async "test activates a script with source code"() {
+    Turbo.setCSPTrustedTypesPolicy(null)
+    const element = document.createElement("script")
+    element.textContent = "foo"
+
+    const activatedElement = activateScriptElement(element)
+    this.assert.equal(activatedElement.textContent, "foo")
+  }
+
+  async "test activates a script with source url"() {
+    Turbo.setCSPTrustedTypesPolicy(null)
+    const element = document.createElement("script")
+    element.src = "https://foo/"
+
+    const activatedElement = activateScriptElement(element)
+    this.assert.equal(activatedElement.src, "https://foo/")
+  }
+}
+
+UtilTests.registerSuite()

--- a/src/util.ts
+++ b/src/util.ts
@@ -16,7 +16,13 @@ export function activateScriptElement(element: HTMLScriptElement) {
     if (cspNonce) {
       createdScriptElement.nonce = cspNonce
     }
-    createdScriptElement.textContent = element.textContent
+    if (element.textContent !== null) {
+      if (CSPTrustedTypesPolicy !== null) {
+        createdScriptElement.textContent = CSPTrustedTypesPolicy.createScript(element.textContent) as string
+      } else {
+        createdScriptElement.textContent = element.textContent
+      }
+    }
     createdScriptElement.async = false
     copyScriptAttributes(createdScriptElement, element)
     return createdScriptElement


### PR DESCRIPTION
When a script is created from the `textContent` of another script we'll need to make sure to run that through `createScript`. Not sure how our existing tests didn't catch this. I'll write some unit tests for `utils.ts` to make sure we do in the future.