### PR TITLE
Bump the turbo version to `7.2.8`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@github/turbo",
-  "version": "7.2.7",
+  "version": "7.2.8",
   "description": "The speed of a single-page web application without having to write any JavaScript",
   "module": "dist/turbo.es2017-esm.js",
   "main": "dist/turbo.es2017-umd.js",


### PR DESCRIPTION
The version fixes a missed injection sink for TrustedTypes, specifically when a `<script>` tag has some `textContent`.

See: https://github.com/github/turbo/pull/8 