### PR TITLE
Potential fixes for 2 code scanning alerts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ on: [push]
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/publish-beta.yml
+++ b/.github/workflows/publish-beta.yml
@@ -1,4 +1,6 @@
 name: Publish Beta Package to npmjs
+permissions:
+  contents: read
 on:
   push:
     branches:


### PR DESCRIPTION

https://github.com/github/prodsec-engineering/issues/748

Potential fixes for 2 code scanning alerts from the [Copilot AutoFix: Missing Permissions in Workflows](https://github.com/orgs/github/security/campaigns/21) security campaign:
- https://github.com/github/turbo/security/code-scanning/12
To fix the issue, we should explicitly add a `permissions` block to the job (or the workflow root) in `.github/workflows/ci.yml`, limiting GITHUB_TOKEN access to the minimal permissions required. Since none of the job steps seem to require write access, the minimal `permissions: contents: read` is sufficient. This block can be placed either at the workflow root (to apply to all jobs) or directly under the `build` job (to apply just to this job). Since only one job is present, either location is suitable, but typically setting it at the job-level is preferred for clarity. The block should be added above the `steps:` section for the `build` job.

  ---
  


- https://github.com/github/turbo/security/code-scanning/11
To fix the problem, add an explicit `permissions` block to the workflow YAML. The minimal safe starting point is to set `contents: read`, which allows the default steps that only need read, while ensuring that no unnecessary write permissions are granted. 

  - In this workflow, it's most appropriate to add the `permissions:` block at the root level, just below the `name:` and above `on:` so the least privilege applies to all jobs unless overridden locally.
  - This only changes the access level of the auto-generated `GITHUB_TOKEN` and does not affect secrets or other tokens.
  - No other code needs to be changed: just one block added to set explicit permissions.

  ---
  


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
